### PR TITLE
possible security issue

### DIFF
--- a/rts51x_scsi.c
+++ b/rts51x_scsi.c
@@ -495,7 +495,10 @@ static int inquiry(struct scsi_cmnd *srb, struct rts51x_chip *chip)
 
 	if (sendbytes > 8) {
 		memcpy(buf, inquiry_buf, 8);
-		memcpy(buf + 8, inquiry_string, sendbytes - 8);
+		if(sendbytes - 8 <= strlen(inquiry_string))
+			memcpy(buf + 8, inquiry_string, sendbytes - 8);
+		else
+			memcpy(buf + 8, inquiry_string, 29);
 		if (pro_formatter_flag)
 			buf[4] = 0x33;	/* Additional Length */
 	} else {

--- a/rts51x_scsi.c
+++ b/rts51x_scsi.c
@@ -498,7 +498,7 @@ static int inquiry(struct scsi_cmnd *srb, struct rts51x_chip *chip)
 		if(sendbytes - 8 <= strlen(inquiry_string))
 			memcpy(buf + 8, inquiry_string, sendbytes - 8);
 		else
-			memcpy(buf + 8, inquiry_string, 29);
+			memcpy(buf + 8, inquiry_string, strlen(inquiry_string));
 		if (pro_formatter_flag)
 			buf[4] = 0x33;	/* Additional Length */
 	} else {


### PR DESCRIPTION
the second parameter to memcpy could be smaller than the size specified
fixed it

While compiling against the 4.12.0-1-hardened kernel, the compiler reports

```
In function ‘memcpy’,
    inlined from ‘inquiry’ at /tmp/yaourt-tmp-cyan/aur-rts5139-git/src/rts5139/rts51x_scsi.c:498:3,
    inlined from ‘rts51x_scsi_handler’ at /tmp/yaourt-tmp-cyan/aur-rts5139-git/src/rts5139/rts51x_scsi.c:1847:10:
./include/linux/string.h:315:4: error: call to ‘__read_overflow2’ declared with attribute error: detected read beyond size of object passed as 2nd parameter
    __read_overflow2();
    ^~~~~~~~~~~~~~~~~~
````