### PR TITLE
Update module to Linux 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ rts5139-y :=				\
 		ms_mg.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build/ SUBDIRS=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) modules
 
 install:
 	cp rts5139.ko /lib/modules/$(shell uname -r)/kernel/drivers/scsi -f

--- a/rts51x.h
+++ b/rts51x.h
@@ -122,7 +122,7 @@ static inline void get_current_time(u8 *timeval_buf, int buf_len)
 	if (!timeval_buf || (buf_len < 8))
 		return;
 
-	do_gettimeofday(&tv);
+	tv = ktime_to_timeval(ktime_get_real());
 
 	timeval_buf[0] = (u8) (tv.tv_sec >> 24);
 	timeval_buf[1] = (u8) (tv.tv_sec >> 16);

--- a/rts51x_scsi.c
+++ b/rts51x_scsi.c
@@ -2117,12 +2117,6 @@ struct scsi_host_template rts51x_host_template = {
 	/* limit the total size of a transfer to 120 KB */
 	.max_sectors = 240,
 
-	/* merge commands... this seems to help performance, but
-	 * periodically someone should test to see which setting is more
-	 * optimal.
-	 */
-	.use_clustering = 1,
-
 	/* emulated HBA */
 	.emulated = 1,
 


### PR DESCRIPTION
Hi, I noticed this module wasn't working anymore on Linux 5.0 on Arch Linux (5.0.0-arch1-1-ARCH) so I decided to try these tweaks. Seems to be working fine now.