### PR TITLE
Updates required for kernel versions >= 5.0.14

### DIFF
--- a/rts51x.c
+++ b/rts51x.c
@@ -97,13 +97,21 @@ static struct usb_class_driver rts51x_class = {
 
 static inline void usb_autopm_enable(struct usb_interface *intf)
 {
-	atomic_set(&intf->pm_usage_cnt, 1);
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 14))
+		atomic_set(&intf->dev.power.usage_count, 1);
+	# else
+		atomic_set(&intf->pm_usage_cnt, 1);
+	# endif
 	usb_autopm_put_interface(intf);
 }
 
 static inline void usb_autopm_disable(struct usb_interface *intf)
 {
-	atomic_set(&intf->pm_usage_cnt, 0);
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 14))
+		atomic_set(&intf->dev.power.usage_count, 0);
+	# else
+		atomic_set(&intf->pm_usage_cnt, 0);
+	# endif
 	usb_autopm_get_interface(intf);
 }
 
@@ -157,11 +165,19 @@ int rts51x_resume(struct usb_interface *iface)
 		mutex_lock(&chip->usb->dev_mutex);
 
 		if (chip->option.ss_en) {
-			if (GET_PM_USAGE_CNT(chip) <= 0) {
-				/* Remote wake up, increase pm_usage_cnt */
-				RTS51X_DEBUGP("Incr pm_usage_cnt\n");
-				SET_PM_USAGE_CNT(chip, 1);
-			}
+			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 14))
+				if (GET_DEV_POWER_USAGE_COUNT(chip) <= 0) {
+					/* Remote wake up, increase dev.power.usage_count */
+					RTS51X_DEBUGP("Incr dev.power.usage_count\n");
+					SET_DEV_POWER_USAGE_COUNT(chip, 1);
+				}
+			# else
+				if (GET_PM_USAGE_CNT(chip) <= 0) {
+					/* Remote wake up, increase pm_usage_cnt */
+					RTS51X_DEBUGP("Incr pm_usage_cnt\n");
+					SET_PM_USAGE_CNT(chip, 1);
+				}
+			# endif
 		}
 
 		RTS51X_SET_STAT(chip, STAT_RUN);
@@ -186,7 +202,12 @@ int rts51x_reset_resume(struct usb_interface *iface)
 	RTS51X_SET_STAT(chip, STAT_RUN);
 
 	if (chip->option.ss_en)
-		SET_PM_USAGE_CNT(chip, 1);
+
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 14))
+			SET_DEV_POWER_USAGE_COUNT(chip, 1);
+		# else
+			SET_PM_USAGE_CNT(chip, 1);
+		# endif
 
 	rts51x_init_chip(chip);
 	rts51x_init_cards(chip);
@@ -805,8 +826,13 @@ static int rts51x_probe(struct usb_interface *intf,
 #ifdef CONFIG_PM
 	if (ss_en) {
 		rts51x->pusb_intf->needs_remote_wakeup = needs_remote_wakeup;
-		SET_PM_USAGE_CNT(chip, 1);
-		RTS51X_DEBUGP("pm_usage_cnt = %d\n", GET_PM_USAGE_CNT(chip));
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 14))
+			SET_DEV_POWER_USAGE_COUNT(chip, 1);
+			RTS51X_DEBUGP("dev.power.usage_count = %d\n", GET_DEV_POWER_USAGE_COUNT(chip));
+		# else
+			SET_PM_USAGE_CNT(chip, 1);
+			RTS51X_DEBUGP("pm_usage_cnt = %d\n", GET_PM_USAGE_CNT(chip));
+		# endif
 	}
 #endif
 

--- a/rts51x.h
+++ b/rts51x.h
@@ -161,10 +161,23 @@ static inline void get_current_time(u8 *timeval_buf, int buf_len)
 #define scsi_unlock(host)	spin_unlock_irq(host->host_lock)
 #define scsi_lock(host)		spin_lock_irq(host->host_lock)
 
-#define GET_PM_USAGE_CNT(chip)	\
-	atomic_read(&((chip)->usb->pusb_intf->pm_usage_cnt))
-#define SET_PM_USAGE_CNT(chip, cnt)	\
-	atomic_set(&((chip)->usb->pusb_intf->pm_usage_cnt), (cnt))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 14))
+
+	/* see https://github.com/torvalds/linux/commit/c2b71462d294cf517a0bc6e4fd6424d7cee5596f#diff-d81b85761c12e5ebdcaca4309ff73cfe */
+
+	#define GET_DEV_POWER_USAGE_COUNT(chip)	\
+		atomic_read(&((chip)->usb->pusb_intf->dev.power.usage_count))
+	#define SET_DEV_POWER_USAGE_COUNT(chip, cnt)	\
+		atomic_set(&((chip)->usb->pusb_intf->dev.power.usage_count), (cnt))
+
+# else
+
+	#define GET_PM_USAGE_CNT(chip)	\
+		atomic_read(&((chip)->usb->pusb_intf->pm_usage_cnt))
+	#define SET_PM_USAGE_CNT(chip, cnt)	\
+		atomic_set(&((chip)->usb->pusb_intf->pm_usage_cnt), (cnt))
+
+# endif
 
 /* Compatible macros while we switch over */
 static inline void *usb_buffer_alloc(struct usb_device *dev, size_t size,


### PR DESCRIPTION
Maintains existing functionality for all previous kernel versions.

Where appropriate, use GET_DEV_POWER_USAGE_COUNT, SET_DEV_POWER_USAGE_COUNT, & dev.power.usage_count for KERNEL_VERSION >= 5.0.14

see https://github.com/asymingt/rts5139/pull/10/commits/10ccaf0372769644ec4ed7ac9712e9cf98bbca07

Tested on:

5.0.14
5.0.17