### PR TITLE
fix for kernel 6.14

### DIFF
--- a/rts51x_scsi.c
+++ b/rts51x_scsi.c
@@ -1923,7 +1923,7 @@ int rts51x_scsi_handler(struct scsi_cmnd *srb, struct rts51x_chip *chip)
  * Host functions
  ***********************************************************************/
 
-int slave_alloc(struct scsi_device *sdev)
+int sdev_init(struct scsi_device *sdev)
 {
 	/*
 	 * Set the INQUIRY transfer length to 36.  We don't use any of
@@ -1934,7 +1934,7 @@ int slave_alloc(struct scsi_device *sdev)
 	return 0;
 }
 
-int slave_configure(struct scsi_device *sdev)
+int sdev_configure(struct scsi_device *sdev, struct queue_limits *limits)
 {
 	/* Scatter-gather buffers (all but the last) must have a length
 	 * divisible by the bulk maxpacket size.  Otherwise a data packet
@@ -2122,8 +2122,8 @@ struct scsi_host_template rts51x_host_template = {
 	/* unknown initiator id */
 	.this_id = -1,
 
-	.slave_alloc = slave_alloc,
-	.slave_configure = slave_configure,
+	.sdev_init = sdev_init,
+	.sdev_configure = sdev_configure,
 
 	/* lots of sg segments can be handled */
 	.sg_tablesize = SG_ALL,
@@ -2171,8 +2171,8 @@ struct scsi_host_template rts51x_host_template = {
 	/* unknown initiator id */
 	.this_id = -1,
 
-	.slave_alloc = slave_alloc,
-	.slave_configure = slave_configure,
+	.sdev_init = sdev_init,
+	.sdev_configure = sdev_configure,
 
 	/* lots of sg segments can be handled */
 	.sg_tablesize = SG_ALL,

--- a/rts51x_scsi.c
+++ b/rts51x_scsi.c
@@ -1923,7 +1923,12 @@ int rts51x_scsi_handler(struct scsi_cmnd *srb, struct rts51x_chip *chip)
  * Host functions
  ***********************************************************************/
 
+/* slave_alloc() was renamed into sdev_init() in kernel 6.14 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
 int sdev_init(struct scsi_device *sdev)
+#else
+int slave_alloc(struct scsi_device *sdev)
+#endif
 {
 	/*
 	 * Set the INQUIRY transfer length to 36.  We don't use any of
@@ -1934,7 +1939,12 @@ int sdev_init(struct scsi_device *sdev)
 	return 0;
 }
 
+/* slave_configure() was removed from kernel 6.14 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
 int sdev_configure(struct scsi_device *sdev, struct queue_limits *limits)
+#else
+int slave_configure(struct scsi_device *sdev)
+#endif
 {
 	/* Scatter-gather buffers (all but the last) must have a length
 	 * divisible by the bulk maxpacket size.  Otherwise a data packet
@@ -2122,8 +2132,14 @@ struct scsi_host_template rts51x_host_template = {
 	/* unknown initiator id */
 	.this_id = -1,
 
+	/* slave_alloc() was renamed & slave_configure() was removed in kernel 6.14 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
 	.sdev_init = sdev_init,
 	.sdev_configure = sdev_configure,
+#else
+	.slave_alloc = slave_alloc,
+	.slave_configure = slave_configure,
+#endif
 
 	/* lots of sg segments can be handled */
 	.sg_tablesize = SG_ALL,
@@ -2171,8 +2187,8 @@ struct scsi_host_template rts51x_host_template = {
 	/* unknown initiator id */
 	.this_id = -1,
 
-	.sdev_init = sdev_init,
-	.sdev_configure = sdev_configure,
+	.slave_alloc = slave_alloc,
+	.slave_configure = slave_configure,
 
 	/* lots of sg segments can be handled */
 	.sg_tablesize = SG_ALL,

--- a/rts51x_scsi.h
+++ b/rts51x_scsi.h
@@ -32,6 +32,7 @@
 #include <linux/blkdev.h>
 #include <linux/completion.h>
 #include <linux/mutex.h>
+#include <linux/version.h>
 #include <scsi/scsi_host.h>
 
 #include "rts51x_chip.h"
@@ -145,8 +146,14 @@ struct Scsi_Host;
 struct scsi_device;
 struct scsi_cmnd;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
 int sdev_init(struct scsi_device *sdev);
 int sdev_configure(struct scsi_device *sdev, struct queue_limits *limits);
+#else
+int slave_alloc(struct scsi_device *sdev);
+int slave_configure(struct scsi_device *sdev);
+#endif
+
 int queuecommand(struct Scsi_Host *, struct scsi_cmnd *);
 int command_abort(struct scsi_cmnd *srb);
 int bus_reset(struct scsi_cmnd *srb);

--- a/rts51x_scsi.h
+++ b/rts51x_scsi.h
@@ -145,8 +145,8 @@ struct Scsi_Host;
 struct scsi_device;
 struct scsi_cmnd;
 
-int slave_alloc(struct scsi_device *sdev);
-int slave_configure(struct scsi_device *sdev);
+int sdev_init(struct scsi_device *sdev);
+int sdev_configure(struct scsi_device *sdev, struct queue_limits *limits);
 int queuecommand(struct Scsi_Host *, struct scsi_cmnd *);
 int command_abort(struct scsi_cmnd *srb);
 int bus_reset(struct scsi_cmnd *srb);


### PR DESCRIPTION
compiles and works successfully on 6.14 kernel, tested on fedora 42 (6.14.4), close #29.
fixed #30, compiles successfully on ubuntu lts 24.04.2 live iso (kernel 6.11).